### PR TITLE
Ensure commits are properly linked to the primary/destination account

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -8,30 +8,41 @@ export function promptUser() {
     output: process.stdout
   });
 
-  rl.question("Please enter GitHub username: ", username => {
-    rl.question("Please enter the minimum year: ", minYear => {
-      rl.question("Please enter the maximum year: ", maxYear => {
-        rl.question("Would you like to execute the script immediately? (yes/no): ", execute => {
-          rl.close();
+  rl.question("Please enter the username of the secondary GitHub account to sync commits from:", username => {
+    rl.question("Please enter the starting year for the range of commits:", minYear => {
+      rl.question("Please enter the ending year for the range of commits:", maxYear => {
+        console.log("To ensure your commits are linked to your primary account, please provide the following details:")
+        rl.question("Please enter the primary account's name:", committerName => {
+          rl.question("Please enter the primary account's email: ", committerEmail => {
+            rl.question("Would you like to execute the script immediately? (yes/no): ", execute => {
+              rl.close();
 
-          if (username && minYear && maxYear) {
-            console.log("\nGenerating script...\n");
+              if (username && minYear && maxYear && committerName && committerEmail) {
+                console.log("\nGenerating script...\n");
 
-            generateCommitScript({username: username, minYear: parseInt(minYear), maxYear: parseInt(maxYear)})
-              .then(() => {
-                if (execute.toLowerCase() === 'yes' || execute.toLowerCase() === 'y') {
-                  console.log("Executing script...\n");
-                  executeScript();
-                } else {
-                  console.log("Script generation completed. You can run the script manually.");
-                }
-              })
-              .catch(error => {
-                console.error(`Error: ${error}`);
-              });
-          } else {
-            console.log("Invalid input. Please provide all the required details.");
-          }
+                generateCommitScript({
+                  username: username, 
+                  minYear: parseInt(minYear), 
+                  maxYear: parseInt(maxYear),
+                  committerName: committerName,
+                  committerEmail: committerEmail
+                })
+                .then(() => {
+                  if (execute.toLowerCase() === 'yes' || execute.toLowerCase() === 'y') {
+                    console.log("Executing script...\n");
+                    executeScript();
+                  } else {
+                    console.log("Script generation completed. You can run the script manually.");
+                  }
+                })
+                .catch(error => {
+                  console.error(`Error: ${error}`);
+                });
+              } else {
+                console.log("Invalid input. Please provide all the required details.");
+              }
+            });
+          });
         });
       });
     });

--- a/src/script.js
+++ b/src/script.js
@@ -26,16 +26,16 @@ function extractCommitDates({ html }) {
   return commitData;
 }
 
-function writeScriptFile({ commitData }) {
+function writeScriptFile(commitData, committerName, committerEmail) {
   let scriptContent = '';
 
   commitData.forEach((commitCount, date) => {
     for (let i = 0; i < commitCount; i++) {
-      const commitMessage = `Sync commit for ${date} #${i + 1}`;
+      const commitMessage = `Sync commit for ${date} [No. ${i + 1}]`;
       // Verificar si el commit ya existe en el historial
       const existingCommit = execSync(`git log --grep="${commitMessage}"`, { encoding: 'utf-8' }).trim();
       if (!existingCommit) {
-        scriptContent += `GIT_COMMITTER_DATE="${date}T00:00:00.000Z" git commit --allow-empty -m "${commitMessage}" --date="${date}T00:00:00.000Z"\n`;
+        scriptContent += `GIT_COMMITTER_NAME="${committerName}" GIT_COMMITTER_EMAIL="${committerEmail}" GIT_COMMITTER_DATE="${date}T00:00:00.000Z" git commit --allow-empty -m "${commitMessage}" --date="${date}T00:00:00.000Z" --author="${committerName} <${committerEmail}>"\n`;
       }
     }
   });
@@ -48,7 +48,7 @@ function writeScriptFile({ commitData }) {
   }
 }
 
-export async function generateCommitScript({ username, minYear, maxYear }) {
+export async function generateCommitScript({ username, minYear, maxYear, committerName, committerEmail }) {
   const commitData = new Map();
 
   for (let year = minYear; year <= maxYear; year++) {
@@ -61,6 +61,5 @@ export async function generateCommitScript({ username, minYear, maxYear }) {
     const datesForYear = extractCommitDates({ html: pageContent });
     datesForYear.forEach((count, date) => commitData.set(date, count));
   }
-
-  writeScriptFile({ commitData: commitData });
+  writeScriptFile(commitData, committerName, committerEmail);
 }


### PR DESCRIPTION
This update addresses an issue with the reliability of `git config user.name` and `git config user.email` when running `bash script.sh`.

To ensure the correct attribution of commits, I have updated the script to include the following changes:

* Added `GIT_COMMITTER_NAME=` and `GIT_COMMITTER_EMAIL=` to explicitly set the committer's information for each individual commit.
* Included the `--author` flag for each commit. This is essential because GitHub differentiates the author from the committer. Without specifying `--author`, the commit may show one person as the author (often linked to my primary account) and another as the committer (probably set by `git config user.name` in my experience). For this case, the commits may not count as the primary account's contribution because it has a different committer.
 
Additionally, I removed the use of the `#` symbol in commit messages, as this inadvertently links to issues filed in the repository.
