### PR TITLE
Fix conficts with issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This CLI tool allows you to sync GitHub contributions by generating commit scripts based on the contribution history of a GitHub user. Ideal for merging commit histories from different accounts into one visual contribution graph.
 
+## CHANGELOG
+
+- 2024-10-20: Now the commits use 'No.' to express the number of commits instead of the '#' character to avoid conflicts with repository issues. - 
+
 ## Features
 
 - **Fetch Contribution History**: Retrieves contribution history from any GitHub user.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sync-graph",
   "type": "module",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generates empty commits to match contributions from other public GitHub accounts.",
   "main": "src/index.js",
   "scripts": {

--- a/src/script.js
+++ b/src/script.js
@@ -31,7 +31,7 @@ function writeScriptFile(commitData, committerName, committerEmail) {
 
   commitData.forEach((commitCount, date) => {
     for (let i = 0; i < commitCount; i++) {
-      const commitMessage = `Sync commit for ${date} #${i + 1}`;
+      const commitMessage = `Sync commit for ${date} [No. ${i + 1}]`;
       // Verificar si el commit ya existe en el historial
       const existingCommit = execSync(`git log --grep="${commitMessage}"`, { encoding: 'utf-8' }).trim();
       if (!existingCommit) {

--- a/src/script.js
+++ b/src/script.js
@@ -32,7 +32,7 @@ function writeScriptFile(commitData, committerName, committerEmail) {
   commitData.forEach((commitCount, date) => {
     for (let i = 0; i < commitCount; i++) {
       const commitMessage = `Sync commit for ${date} [No. ${i + 1}]`;
-      // Verificar si el commit ya existe en el historial
+      // Check if the commit already exists in the history
       const existingCommit = execSync(`git log --grep="${commitMessage}"`, { encoding: 'utf-8' }).trim();
       if (!existingCommit) {
         scriptContent += `GIT_COMMITTER_NAME="${committerName}" GIT_COMMITTER_EMAIL="${committerEmail}" GIT_COMMITTER_DATE="${date}T00:00:00.000Z" git commit --allow-empty -m "${commitMessage}" --date="${date}T00:00:00.000Z" --author="${committerName} <${committerEmail}>"\n`;


### PR DESCRIPTION
Problem: https://github.com/isturiz/sync-graph/pull/5#issue-2587388810

Quote: 'Additionally, I removed the use of the # symbol in commit messages, as
this inadvertently links to issues filed in the repository.'

Solution: change '#' character to 'No.' to express the commit number.

New problems: This change breaks backward compatibility with how commits were previously compared. Now, the commits use the "No." format to number them instead of the "#" character. This can lead to duplicate commits in the history if not handled properly.

Solution:
To prevent duplicate commits, it's recommended to delete the .git directory and force a new `push` using `--force` flag. Alternatively, you can create a new repository, delete the old one, and sync the commits in the new repository to ensure there are no conflicts or duplicates in the history.

Thanks to @apappas1129 for pointing out the issue.